### PR TITLE
update

### DIFF
--- a/emnl-woocommerce-later-delivery-on-demand.php
+++ b/emnl-woocommerce-later-delivery-on-demand.php
@@ -105,36 +105,23 @@ function emnl_later_delivery_on_demand()
 
         } else {
             $checked = false;
-            WC()->session->set('emnl-later-delivery-instructions','');
+            WC()->session->set('emnl-later-delivery-date', '');
             WC()->session->set('emnl-later-delivery-checkbox-selection', false);
         }
 
 
-        if (isset($posted_data['emnl-later-delivery-date']) && !empty($posted_data['emnl-later-delivery-date'])) {
-
-            $validate_date = explode('-', $posted_data['emnl-later-delivery-date']);
-
-            if (is_array($validate_date) && count($validate_date) === 3 && checkdate($validate_date[1], $validate_date[2], $validate_date[0])) {
-                WC()->session->set('emnl-later-delivery-date', $posted_data['emnl-later-delivery-date']);
-                $date = $posted_data['emnl-later-delivery-date'];
-            }
-
-        }
-    }
-
-    //calculate min date within 7 days and check selected date against it
-
-    $min_date = date('Y-m-d', strtotime(date('Y-m-d') . '+7 days'));
-    if (empty($date)) {
-        $date = $min_date;
-    } else {
-
-        if (strtotime($min_date) > strtotime($date)) {
-            $date = $min_date;
-            WC()->session->set('emnl-later-delivery-date', $date);
+        if ($checked && isset($posted_data['emnl-later-delivery-date']) && !empty($posted_data['emnl-later-delivery-date'])) {
+            WC()->session->set('emnl-later-delivery-date', $posted_data['emnl-later-delivery-date']);
+            $date = $posted_data['emnl-later-delivery-date'];
+        } else {
+            //reset the date session data
+            WC()->session->set('emnl-later-delivery-date', '');
+            $date = '';
 
         }
     }
+
+
 
 
     // Create the later delivery checkbox
@@ -154,7 +141,7 @@ function emnl_later_delivery_on_demand()
 
         jQuery(document).ready(function ($) {
             
-                $("#emnl-later-delivery-date").on("change", function () {
+                $("#emnl-later-delivery-date").on("focusout", function () {
                     $(document.body).trigger("update_checkout");
                 });
         });
@@ -177,8 +164,9 @@ function emnl_later_delivery_on_demand()
         echo '</small>';
         echo '</p>';
         $delivery_instructions = ob_get_clean();
-        WC()->session->set('emnl-later-delivery-instructions', $delivery_instructions);
         echo $delivery_instructions;
+        //calculate min date within 7 days
+        $min_date = date('Y-m-d', strtotime(date('Y-m-d') . '+7 days'));
 
         woocommerce_form_field('emnl-later-delivery-date', array(
             'type' => 'date',
@@ -212,7 +200,7 @@ function emnl_modify_shipping_method_title($item, $package_key, $package, $order
 {
     if (isset($_POST['emnl-later-delivery-checkbox']) && isset($_POST['emnl-later-delivery-date']) && !empty($_POST['emnl-later-delivery-date'])) {
 
-        $formatted_date = date(get_option('date_format'), strtotime($_POST['emnl-later-delivery-date']));
+        $formatted_date = date_i18n(get_option('date_format'), strtotime($_POST['emnl-later-delivery-date']));
         $item->set_name($item->get_name() . ' (op afroep vanaf ' . strtolower($formatted_date) . ')');
     }
 
@@ -244,7 +232,7 @@ function emnl_woocommerce_cart_shipping_method_full_label($label, $method)
             }
 
             if (!empty($date)) {
-                $formatted_date = date(get_option('date_format'), strtotime($date));
+                $formatted_date = date_i18n(get_option('date_format'), strtotime($date));
 
                 $label .= ' (op afroep vanaf ' . strtolower($formatted_date) . ')';
             }
@@ -302,49 +290,114 @@ function custom_checkout_field_validation_process($data, $errors)
 
     if (isset($_POST['emnl-later-delivery-date']) && !empty($_POST['emnl-later-delivery-date'])) {
         $validate_date = explode('-', $_POST['emnl-later-delivery-date']);
-        if (!is_array($validate_date) || count($validate_date) !== 3 || !checkdate($validate_date[1], $validate_date[2], $validate_date[0])) {
+        $min_date = date('Y-m-d', strtotime(date('Y-m-d') . '+7 days'));
+
+        if (
+            !is_array($validate_date) || count($validate_date) !== 3 || !checkdate($validate_date[1], $validate_date[2], $validate_date[0])
+            || strtotime($min_date) > strtotime($_POST['emnl-later-delivery-date'])
+        ) {
 
 
-            $errors->add('requirements', __("Please fill in a valid date!", "woocommerce"));
+            $errors->add('requirements', __("Please fill in a valid date which is minimal 7 days in the future!", "woocommerce"));
+
+
+
+
+        } else {
+            //all good , save the date to session
+            WC()->session->set('emnl-later-delivery-date', $_POST['emnl-later-delivery-date']);
 
         }
+
     }
 
 
 }
 
 
-add_action('woocommerce_checkout_update_order_meta', 'wordimpress_custom_checkout_field_update_order_meta');
-/**
- * @brief Save the New Checkout Fields Upon Successful Order , only if the delivery later option was selected
- * @param $order_id
- */
-function wordimpress_custom_checkout_field_update_order_meta($order_id)
-{
-    //check if $_POST has our custom fields, and save them if true
-    $order = wc_get_order($order_id);
-    if ($order && isset($_POST['emnl-later-delivery-checkbox']) && isset($_POST['emnl-later-delivery-date']) && !empty($_POST['emnl-later-delivery-date'])) {
-        $order->update_meta_data('emnl_later_delivery_instructions', WC()->session->get('emnl-later-delivery-instructions'));
-        $order->save();
-    }
-}
 
 
-add_action('woocommerce_email_order_meta', 'emnl_email_output_delivery_instructions', 20);
+add_action('woocommerce_email_order_meta', 'emnl_email_output_delivery_instructions', 20,2);
 
 /**
  * @brief output delivery instructions in relevant emails
  * @param $order
+ * @param $sent_to_admin
  */
-function emnl_email_output_delivery_instructions($order)
+function emnl_email_output_delivery_instructions($order,$sent_to_admin)
 {
-    if ($order) {
-        $delivery_instructions = $order->get_meta('emnl_later_delivery_instructions', true);
+    if ($order && !$sent_to_admin && strpos($order->get_shipping_method(),'op afroep') !== false ) {
 
-        if (!empty($delivery_instructions)) {
+        //generate message
 
-                echo $delivery_instructions;
+        // Define verbs in case of shipping method: pick up instead of delivery
+        if (stristr($order->get_shipping_method(), 'afhalen')) {
+
+            $later_delivery_verb1 = 'afhaal';
+            $later_delivery_verb2 = 'afhalen';
+            $later_delivery_verb3 = 'afhaling';
+
+        } else {
+
+            $later_delivery_verb1 = 'bezorg';
+            $later_delivery_verb2 = 'bezorgen';
+            $later_delivery_verb3 = 'bezorging';
+
         }
+
+        // Retrieve shipping method transit times to calculate their respective planning times
+        if (stristr($order->get_shipping_method(), 'pakketpost')) {
+
+            // Pakketpost
+            if (defined('EMNL_UNILIVING_SHIPPING_TIME_STOCK_PRODUCTS_PAKKETPOST_IN_DAYS')) {
+                $later_delivery_planning_days = EMNL_UNILIVING_SHIPPING_TIME_STOCK_PRODUCTS_PAKKETPOST_IN_DAYS;
+            }
+
+        } elseif (stristr($order->get_shipping_method(), 'bezorging op afspraak')) {
+
+            // Bezorgen op afspraak
+            if (defined('EMNL_UNILIVING_SHIPPING_TIME_STOCK_PRODUCTS_NO_PAKKETPOST_IN_DAYS')) {
+                $later_delivery_planning_days = EMNL_UNILIVING_SHIPPING_TIME_STOCK_PRODUCTS_NO_PAKKETPOST_IN_DAYS;
+            }
+
+        } elseif (stristr($order->get_shipping_method(), 'afhalen na afspraak')) {
+
+            // Afhalen
+            $later_delivery_planning_days = 1;
+
+        } else {
+
+            // Fallback
+            $later_delivery_planning_days = 14;
+
+        }
+
+        // Convert planning days to a nice human readable sentence
+        if ($later_delivery_planning_days === 1) {
+            $later_delivery_planning_text = $later_delivery_planning_days . ' werkdag';
+        } elseif ($later_delivery_planning_days <= 5) {
+            $later_delivery_planning_text = $later_delivery_planning_days . ' werkdagen';
+        } else {
+
+            $later_delivery_planning_days_unrounded = $later_delivery_planning_days / 7;
+            $later_delivery_planning_weeks = ceil($later_delivery_planning_days_unrounded);
+            $later_delivery_planning_text = $later_delivery_planning_weeks . ' weken';
+
+        }
+
+        // Create the later delivery instructions
+        ob_start();
+        echo '<p>';
+        echo '<small>';
+        echo 'Let op: uw bestelling komt op "op afroep". ';
+        echo 'Wij nemen in principe géén contact met u op voor het maken van een ' . $later_delivery_verb1 . 'afspraak. ';
+        echo 'U dient z.s.m. of <strong><u>uiterlijk ' . $later_delivery_planning_text . ' ';
+        echo 'vóór de gewenste ' . $later_delivery_verb1 . 'datum</u></strong> ';
+        echo 'contact met ons op te nemen om een ' . $later_delivery_verb1 . 'afspraak in te plannen.';
+        echo '</small>';
+        echo '</p>';
+        $delivery_instructions = ob_get_clean();
+        echo $delivery_instructions;
 
     }
 }


### PR DESCRIPTION
* replaced function date()  with dateil8n() in display areas
* changes jquery event for date field update from "change" to "focusout"
* set date field to be empty by default
* validate date only when customer attempt to place order and updated
validation message
* set delivry instruction to be only displayed in customer emails
* delivery instructions are no longer stored in meta and are generated
during email content creation.